### PR TITLE
lambdaHandlerを実装

### DIFF
--- a/fib-api/app.ts
+++ b/fib-api/app.ts
@@ -1,4 +1,5 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { fibonacci } from './src/fibonacci';
 
 /**
  *
@@ -11,11 +12,39 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
  */
 
 export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    const nQueryParam = event.queryStringParameters?.n;
+    if (typeof nQueryParam === 'undefined') {
+        return {
+            statusCode: 400,
+            body: JSON.stringify({
+                message: 'Query parameter "n" is required.',
+            }),
+        };
+    }
+    if (nQueryParam === '') {
+        return {
+            statusCode: 400,
+            body: JSON.stringify({
+                message: 'Query parameter "n" must not be empty.',
+            }),
+        };
+    }
+    const n = Number(nQueryParam);
+    if (n < 1 || !Number.isInteger(n)) {
+        return {
+            statusCode: 400,
+            body: JSON.stringify({
+                message: 'Query parameter "n" must be a positive integer.',
+            }),
+        };
+    }
+
     try {
+        const result = fibonacci(n);
         return {
             statusCode: 200,
             body: JSON.stringify({
-                message: 'hello world',
+                result: result.toString(), // bigintを文字列に変換
             }),
         };
     } catch (err) {
@@ -23,7 +52,7 @@ export const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGat
         return {
             statusCode: 500,
             body: JSON.stringify({
-                message: 'some error happened',
+                message: 'An error occurred during the calculation.',
             }),
         };
     }

--- a/fib-api/tests/unit/test-handler.test.ts
+++ b/fib-api/tests/unit/test-handler.test.ts
@@ -11,9 +11,9 @@ describe('Unit test for app handler', function () {
             isBase64Encoded: false,
             multiValueHeaders: {},
             multiValueQueryStringParameters: {},
-            path: '/hello',
+            path: '/fib',
             pathParameters: {},
-            queryStringParameters: {},
+            queryStringParameters: { n: '10' },
             requestContext: {
                 accountId: '123456789012',
                 apiId: '1234',
@@ -42,12 +42,12 @@ describe('Unit test for app handler', function () {
                     userAgent: '',
                     userArn: '',
                 },
-                path: '/hello',
+                path: '/dev/fib',   // あやしい
                 protocol: 'HTTP/1.1',
                 requestId: 'c6af9ac6-7b61-11e6-9a41-93e8deadbeef',
                 requestTimeEpoch: 1428582896000,
                 resourceId: '123456',
-                resourcePath: '/hello',
+                resourcePath: '/fib',
                 stage: 'dev',
             },
             resource: '',
@@ -58,7 +58,7 @@ describe('Unit test for app handler', function () {
         expect(result.statusCode).toEqual(200);
         expect(result.body).toEqual(
             JSON.stringify({
-                message: 'hello world',
+                result: '55',
             }),
         );
     });


### PR DESCRIPTION
### 概要
Issue #3 および PR #4 にて実装したフィボナッチ数を計算する関数を，lambdaHandlerから呼び出すコードを実装。

### 変更内容
- クエリパラメータ`n`を受け取って`fibonacci`関数を呼び出して返す部分の実装
- リクエストのバリデーション。受理できなければstatus 400で返す
  - クエリパラメータnが存在しない場合
  - クエリパラメータnが空の場合
  - クエリパラメータが正の整数の場合
- `fibonacci`関数内部でエラーが発生した場合のエラーハンドリング  
  あまり考えられないが，もし発生した場合status code 500とともに失敗した旨返す
- ローカルLambda呼出のユニットテスト追加

### テスト
今回追加したテストおよび既存のjestテストを実行。

### 関連Issue
#5